### PR TITLE
Improve library / reader URN heuristics  

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,3 +1,12 @@
 # Scaife Viewer :: Core functionality
 
-This package was extracted from [https://github.com/scaife-viewer/scaife-viewer](https://github.com/scaife-viewer/scaife-viewer)
+This package was extracted from
+[https://github.com/scaife-viewer/scaife-viewer](https://github.com/scaife-viewer/scaife-viewer)
+
+## Settings
+
+### ALLOW_TRAILING_COLON
+Default: `False`
+
+When `False`, to maintain compatability with the MyCapitain resolver,
+the trailing colon will be stripped from URNs.

--- a/core/scaife_viewer/core/conf.py
+++ b/core/scaife_viewer/core/conf.py
@@ -1,0 +1,10 @@
+from django.conf import settings  # noqa
+
+from appconf import AppConf
+
+
+class CoreAppConf(AppConf):
+    ALLOW_TRAILING_COLON = False
+
+    class Meta:
+        prefix = "scaife_viewer_core"

--- a/core/scaife_viewer/core/cts/__init__.py
+++ b/core/scaife_viewer/core/cts/__init__.py
@@ -11,13 +11,13 @@ from .collections import (  # noqa
 )
 from .exceptions import (  # noqa
     CollectionDoesNotExist,
-    PassageDoesNotExist,
     InvalidPassageReference,
     InvalidURN,
+    PassageDoesNotExist,
 )
+from .heal import heal
 from .passage import Passage
 from .reference import URN
-from .heal import heal
 
 
 def text_inventory() -> TextInventory:

--- a/core/scaife_viewer/core/search.py
+++ b/core/scaife_viewer/core/search.py
@@ -2,6 +2,7 @@ from operator import itemgetter
 
 from django.conf import settings
 from django.urls import reverse
+from django.utils.functional import SimpleLazyObject
 
 import regex
 from elasticsearch import Elasticsearch
@@ -10,11 +11,20 @@ from elasticsearch.helpers import scan as scanner
 from . import cts
 
 
-es = Elasticsearch(
-    hosts=settings.ELASTICSEARCH_HOSTS,
-    sniff_on_start=settings.ELASTICSEARCH_SNIFF_ON_START,
-    sniff_on_connection_fail=settings.ELASTICSEARCH_SNIFF_ON_CONNECTION_FAIL,
-)
+def default_es_client_config():
+    return dict(
+        hosts=settings.ELASTICSEARCH_HOSTS,
+        sniff_on_start=settings.ELASTICSEARCH_SNIFF_ON_START,
+        sniff_on_connection_fail=settings.ELASTICSEARCH_SNIFF_ON_CONNECTION_FAIL,
+    )
+
+
+def get_es_client():
+    return Elasticsearch(**default_es_client_config())
+
+
+es = SimpleLazyObject(get_es_client)
+
 
 """
 From https://www.elastic.co/guide/en/elasticsearch/reference/6.0/search-request-highlighting.html#boundary-scanners:

--- a/core/scaife_viewer/core/tests/fixtures/templates/site_base.html
+++ b/core/scaife_viewer/core/tests/fixtures/templates/site_base.html
@@ -1,0 +1,1 @@
+{% comment %} left intentinoally blank {% endcomment %}

--- a/core/scaife_viewer/core/tests/fixtures/ti.xml
+++ b/core/scaife_viewer/core/tests/fixtures/ti.xml
@@ -1,0 +1,49 @@
+<GetCapabilities xmlns="http://chs.harvard.edu/xmlns/cts">
+      <request>
+            <requestName>GetInventory</requestName>
+            <requestFilters>urn=None</requestFilters>
+      </request>
+      <reply>
+            <TextInventory tiid="defaultTic"
+                  xmlns:ns1="http://purl.org/dc/elements/1.1/"
+                  xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                  xmlns:dts="http://w3id.org/dts-ontology/"
+                  xmlns="http://chs.harvard.edu/xmlns/cts"
+                  xmlns:ns2="http://purl.org/dc/terms/"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+                  <textgroup urn="urn:cts:greekLit:tlg0096">
+                        <groupname xml:lang="eng">Aesop</groupname>
+                        <work urn="urn:cts:greekLit:tlg0096.tlg002" xml:lang="grc" groupUrn="urn:cts:greekLit:tlg0096">
+                              <title xml:lang="lat">Fabulae</title>
+                              <edition urn="urn:cts:greekLit:tlg0096.tlg002.First1K-grc1" xml:lang="grc" workUrn="urn:cts:greekLit:tlg0096.tlg002">
+                                    <label xml:lang="lat">Fabulae Aesopicae Collectae</label>
+                                    <label xml:lang="grc">ΑΙΣΩΠΕΙΩΝ ΜΥΘΩΝ ΣΥΝΑΓΩΓΗ</label>
+                                    <description xml:lang="lat">Fabulae Aesopicae Collectae, Halm, Teubner, 1872</description>
+                                    <online>
+                                          <citationMapping>
+                                                <citation xpath="/tei:div[@n='?']" scope="/tei:TEI/tei:text/tei:body/tei:div" label="fabula"></citation>
+                                          </citationMapping>
+                                    </online>
+                              </edition>
+                        </work>
+                  </textgroup>
+                  <textgroup urn="urn:cts:greekLit:tlg4031">
+                        <groupname xml:lang="lat">Eustratius</groupname>
+                        <work urn="urn:cts:greekLit:tlg4031.tlg002" xml:lang="grc" groupUrn="urn:cts:greekLit:tlg4031">
+                              <title xml:lang="lat">In Aristotelis Ethica Nicomachea I Commentaria</title>
+                              <edition urn="urn:cts:greekLit:tlg4031.tlg002.opp-grc1" xml:lang="grc" workUrn="urn:cts:greekLit:tlg4031.tlg002">
+                                    <label xml:lang="lat">In Aristotelis Ethica Nicomachea I Commentaria</label>
+                                    <description xml:lang="mul">Eustratius, In Aristotelis Ethica Nicomachea I Commentaria, Commentaria in Aristotelem Graeca 20,
+    Reimer, Heylbut, 1892</description>
+                                    <online>
+                                          <citationMapping>
+                                                <citation xpath="/tei:div[@n='?']" scope="/tei:TEI/tei:text/tei:body/tei:div" label="chapter"></citation>
+                                          </citationMapping>
+                                    </online>
+                              </edition>
+                        </work>
+                  </textgroup>
+            </TextInventory>
+      </reply>
+</GetCapabilities>

--- a/core/scaife_viewer/core/tests/settings.py
+++ b/core/scaife_viewer/core/tests/settings.py
@@ -16,9 +16,7 @@ MIDDLEWARE = []
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [
-            # insert your TEMPLATE_DIRS here
-        ],
+        "DIRS": ["scaife_viewer/core/tests/fixtures/templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -39,3 +37,14 @@ DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memor
 SITE_ID = 1
 ROOT_URLCONF = "scaife_viewer.core.tests.urls"
 SECRET_KEY = "notasecret"
+
+CTS_API_ENDPOINT = os.environ.get(
+    "CTS_API_ENDPOINT", "https://scaife-cts-dev.perseus.org/api/cts"
+)
+CTS_RESOLVER = {
+    "type": "api",
+    "kwargs": {"endpoint": CTS_API_ENDPOINT},
+}
+CTS_LOCAL_TEXT_INVENTORY = "scaife_viewer/core/tests/fixtures/ti.xml"
+
+DEPLOYMENT_TIMESTAMP_VAR_NAME = "foo"

--- a/core/scaife_viewer/core/tests/tests.py
+++ b/core/scaife_viewer/core/tests/tests.py
@@ -1,6 +1,42 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from ..utils import normalize_urn
 
 
-class Tests(TestCase):
-    def setUp(self):
-        pass
+class URNTests(TestCase):
+    def test_urn_normalized(self):
+        provided_urn = "urn:cts:greekLit:tlg0096.tlg002.First1K-grc1:"
+        acceptable_urn = "urn:cts:greekLit:tlg0096.tlg002.First1K-grc1"
+        result = normalize_urn(provided_urn)
+        assert result == acceptable_urn
+
+    @override_settings(SCAIFE_VIEWER_CORE_ALLOW_TRAILING_COLON=True)
+    def test_urn_trailing_colon_not_normalized(self):
+        provided_urn = "urn:cts:greekLit:tlg0096.tlg002.First1K-grc1:"
+        result = normalize_urn(provided_urn)
+        assert result == provided_urn
+
+    def test_urn_unmodified(self):
+        provided_urn = "urn:cts:greekLit:tlg0096.tlg002.First1K-grc1"
+        result = normalize_urn(provided_urn)
+        assert result == provided_urn
+
+
+class ViewTests(TestCase):
+    def test_reader_version_urn_redirects_to_first_passage(self):
+        urn = "urn:cts:greekLit:tlg0096.tlg002.First1K-grc1"
+        reader_url = reverse("reader", kwargs={"urn": urn})
+        response = self.client.get(reader_url, follow=True)
+        assert len(response.redirect_chain) == 2
+        assert (
+            response.wsgi_request.path
+            == "/reader/urn:cts:greekLit:tlg0096.tlg002.First1K-grc1:1-4b/"
+        )
+
+    def test_reader_work_urn_redirects_to_library(self):
+        urn = "urn:cts:greekLit:tlg0096.tlg002"
+        reader_url = reverse("reader", kwargs={"urn": urn})
+        response = self.client.get(reader_url, follow=True)
+        assert len(response.redirect_chain) == 2
+        assert response.wsgi_request.path == "/library/urn:cts:greekLit:tlg0096.tlg002/"

--- a/core/scaife_viewer/core/urls.py
+++ b/core/scaife_viewer/core/urls.py
@@ -1,1 +1,18 @@
-urlpatterns = []
+from django.urls import path
+
+from .views import LibraryCollectionView, Reader, library_text_redirect
+
+
+urlpatterns = [
+    path(
+        "library/<str:urn>/",
+        LibraryCollectionView.as_view(format="html"),
+        name="library_collection",
+    ),
+    path(
+        "library/<str:urn>/redirect/",
+        library_text_redirect,
+        name="library_text_redirect",
+    ),
+    path("reader/<str:urn>/", Reader.as_view(), name="reader"),
+]

--- a/core/scaife_viewer/core/utils.py
+++ b/core/scaife_viewer/core/utils.py
@@ -1,9 +1,13 @@
+import logging
 import math
 
 from django.urls import reverse
 
 from . import cts
 from .conf import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 def link_collection(urn) -> dict:
@@ -122,6 +126,8 @@ def get_pagination_info(total_count, page_num):
 
 def normalize_urn(urn):
     if not settings.SCAIFE_VIEWER_CORE_ALLOW_TRAILING_COLON and urn.endswith(":"):
-        # @@@ logging
-        urn = urn[:-1]
+        new_urn = urn[:-1]
+        msg = f'Normalized "{urn}" to "{new_urn}"'
+        logger.info(msg)
+        return new_urn
     return urn

--- a/core/scaife_viewer/core/utils.py
+++ b/core/scaife_viewer/core/utils.py
@@ -3,6 +3,7 @@ import math
 from django.urls import reverse
 
 from . import cts
+from .conf import settings
 
 
 def link_collection(urn) -> dict:
@@ -117,3 +118,10 @@ def get_pagination_info(total_count, page_num):
         "has_next": has_next,
         "num_pages": num_pages,
     }
+
+
+def normalize_urn(urn):
+    if not settings.SCAIFE_VIEWER_CORE_ALLOW_TRAILING_COLON and urn.endswith(":"):
+        # @@@ logging
+        urn = urn[:-1]
+    return urn

--- a/core/scaife_viewer/core/views.py
+++ b/core/scaife_viewer/core/views.py
@@ -235,7 +235,6 @@ def library_text_redirect(request, urn):
     Given a text URN redirect to the first chunk. Required to prevent
     TOCing on the top-level library page.
     """
-    # @@@ how to indicate that healing has happened
     urn = normalize_urn(urn)
 
     try:

--- a/core/scaife_viewer/core/views.py
+++ b/core/scaife_viewer/core/views.py
@@ -21,7 +21,13 @@ from . import cts
 from .http import ConditionMixin
 from .precomputed import library_view_json
 from .search import SearchQuery
-from .utils import apify, encode_link_header, get_pagination_info, link_passage
+from .utils import (
+    apify,
+    encode_link_header,
+    get_pagination_info,
+    link_passage,
+    normalize_urn,
+)
 
 
 class BaseLibraryView(View):
@@ -74,6 +80,10 @@ class LibraryCollectionView(LibraryConditionMixin, BaseLibraryView):
             raise Http404()
 
     def as_html(self):
+        normalized_urn = normalize_urn(self.kwargs["urn"])
+        if normalized_urn != self.kwargs["urn"]:
+            return redirect("library_collection", urn=normalized_urn)
+
         collection = self.get_collection()
         collection_name = collection.__class__.__name__.lower()
         ctx = {collection_name: collection}

--- a/core/scaife_viewer/core/views.py
+++ b/core/scaife_viewer/core/views.py
@@ -222,8 +222,6 @@ class Reader(TemplateView):
             text = cts.collection(self.urn.upTo(cts.URN.NO_PASSAGE))
         except cts.CollectionDoesNotExist:
             raise Http404()
-        # @@@ KeyError is a possibility if the URN is for a text group
-        # or work
         return text
 
     def get_context_data(self, **kwargs):
@@ -245,7 +243,7 @@ def library_text_redirect(request, urn):
     except cts.CollectionDoesNotExist:
         raise Http404()
     if not isinstance(text, cts.Text):
-        raise Http404()
+        return redirect("library_collection", urn=urn)
     passage = text.first_passage()
     if not passage:
         raise Http404()

--- a/core/setup.py
+++ b/core/setup.py
@@ -28,6 +28,7 @@ setup(
         "anytree==2.4.3",
         "certifi==2018.11.29",
         "dask[bag]==1.1.0",
+        "django_appconf>=1.0.4",
         "Django>=2.2,<3.0",
         "elasticsearch==6.3.1",
         "google-auth==1.6.2",


### PR DESCRIPTION
# What's in this PR?

Users of the [PDL's Scaife Viewer instance](https://scaife.perseus.org/) have filed multiple feature requests and bug reports on how to better interpret URNs in reader / library contexts.

This PR improves URN handling as follows:
- When in a reader context, if a URN has no [passage component](http://cite-architecture.github.io/ctsurn_spec/#syntax-of-a-cts-urn), and can be resolved to a version, Scaife Viewer will load the first passage for the given version.
- If a text group or work URN is provided in a reader context, Scaife Viewer will attempt to resolve that URN to a library context
- The [CTS URN spec](http://cite-architecture.github.io/ctsurn_spec/#syntax-of-a-cts-urn) dictates that:
> The value of the passage component may be a null string; in this case, the work component must still be separated from the null string by a colon. 

Currently, the underlying Nautulus resolver used by Scaife Viewer cannot handle this syntax.  The `core` package provides a setting, `SCAIFE_VIEWER_CORE_ALLOW_TRAILING_COLON` that defaults to `False`.

In circumstances were a URN with a trailing colon is detected, the colon is trimmed from the URN.

As a practical example, in a reader context (e.g. `/reader/urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:`), Scaife Viewer will trim the trailing colon and then redirect to the first passage (`/reader/urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.30/`).

In a library context, `/library/urn:cts:greekLit:tlg0012.tlg001:/`, Scaife Viewer will trim the trailing colon and redirect to `/library/urn:cts:greekLit:tlg0012.tlg001/`.

In the future, when the CTS resolver in Scaife Viewer can properly handle the trailing colon, the default value for `SCAIFE_VIEWER_CORE_ALLOW_TRAILING_COLON` could be changed to `True` and / or a new setting to _enforce_ the trailing colon on work component without a passage component.

## Other changes
- Stubs out fixtures to run Django view tests; in the future, these may be removed in favor of the `django-test-plus` runner (which allows us to evaluate views without rendering out a response)
- Lazily-instantiates the ElasticSearch requirement (so that we do not need to have an ElasticSearch service up and running to run tests)

## Related issues
- https://github.com/scaife-viewer/scaife-viewer/issues/420
- https://github.com/scaife-viewer/scaife-viewer/issues/377
- https://github.com/scaife-viewer/scaife-viewer/issues/279
- https://github.com/scaife-viewer/scaife-viewer/issues/444
- https://github.com/scaife-viewer/scaife-viewer/issues/446