### PR TITLE
Retire DATA_MODEL_ID setting

### DIFF
--- a/atlas/README.md
+++ b/atlas/README.md
@@ -13,14 +13,6 @@ Default: `None`
 
 The path to the directory containing ATLAS data
 
-**DATA_MODEL_ID**
-
-Default: A base64 encoded representation of the last release (in `YYYY-MM-DD-###` format) where a
-backwards incompatible schema change occurred.
-
-Site developers can use the value of this setting to help inform when ATLAS content should be re-ingested
-due to BI schema changes.
-
 **INGESTION_CONCURRENCY**
 
 Default: `None`

--- a/atlas/scaife_viewer/atlas/conf.py
+++ b/atlas/scaife_viewer/atlas/conf.py
@@ -1,4 +1,3 @@
-import base64
 import importlib
 
 from django.conf import settings  # noqa
@@ -26,7 +25,6 @@ def load_path_attr(path):
 class ATLASAppConf(AppConf):
     # Data model
     DATA_DIR = None
-    DATA_MODEL_ID = base64.b64encode(b"2020-09-08-001\n").decode()
     INGESTION_CONCURRENCY = None
     NODE_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 

--- a/atlas/scaife_viewer/atlas/data_model.py
+++ b/atlas/scaife_viewer/atlas/data_model.py
@@ -1,0 +1,15 @@
+import base64
+
+
+"""
+`VERSION` is a base64 encoded representation of the last ATLAS release
+(in `YYYY-MM-DD-###` format) where a backwards incompatible schema change
+occurred.
+
+Site developers can use the value of this setting to help inform when ATLAS
+content should be re-ingested due to BI schema changes, e.g.:
+
+* Leveraging the `prepare_atlas_db` management command
+* Comparing a site-level setting to the current VERSION constant
+"""
+VERSION = base64.b64encode(b"2020-09-08-001\n").decode()

--- a/atlas/setup.py
+++ b/atlas/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email="jtauber+scaife@jtauber.com",
     description="Aligned Text and Linguistic Annotation Server (ATLAS)",
     name="scaife-viewer-atlas",
-    version="0.1a7",
+    version="0.1a8",
     url="http://github.com/scaife-viewer/backend/",
     license="MIT",
     packages=find_packages(),


### PR DESCRIPTION
We cannot import from atlas.conf in a project-level settings file due to circular import issues.

The intent of `DATA_MODEL_ID` was to provide a value that could be used by site developers to customize when an ATLAS database would be re-used _OR_ re-created.

Moving to a special `data_model.VERSION` constant allows the value to be imported / inspected within `settings.py`.