### PR TITLE
Update search indexer

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -17,3 +17,11 @@ the trailing colon will be stripped from URNs.
 Default: `"scaife_viewer.core.hooks.DefaultHookSet"`
 
 The path to a hookset that can be used to customize package functionality.
+
+
+### USE_CLOUD_INDEXER
+
+Default: `False`
+
+When `True`, sets GCE-specific metadata for the search index management
+command

--- a/core/scaife_viewer/core/conf.py
+++ b/core/scaife_viewer/core/conf.py
@@ -28,6 +28,9 @@ class CoreAppConf(AppConf):
     # Other
     HOOKSET = "scaife_viewer.core.hooks.DefaultHookSet"
 
+    # Search Indexing
+    USE_CLOUD_INDEXER = False
+
     class Meta:
         prefix = "scaife_viewer_core"
 

--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -161,7 +161,7 @@ class Indexer:
             leaves = PreOrderIter(toc.root, filter_=attrgetter("is_leaf"))
             for i, node in enumerate(leaves):
                 passages.append(
-                    SortedPassage(urn=f"{text.urn}:{node.reference}", sort_idx=i)
+                    SortedPassage(urn=f"{text.urn}:{node.reference}", sort_idx=i,)
                 )
         return passages
 

--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -13,6 +13,7 @@ from anytree.iterators import PreOrderIter
 
 from . import cts
 from .morphology import Morphology
+from .search import default_es_client_config
 
 
 morphology = None
@@ -216,11 +217,7 @@ class DirectPusher:
     @property
     def es(self):
         if not hasattr(self, "_es"):
-            self._es = elasticsearch.Elasticsearch(
-                hosts=settings.ELASTICSEARCH_HOSTS,
-                sniff_on_start=settings.ELASTICSEARCH_SNIFF_ON_START,
-                sniff_on_connection_fail=settings.ELASTICSEARCH_SNIFF_ON_CONNECTION_FAIL,
-            )
+            self._es = elasticsearch.Elasticsearch(**default_es_client_config())
         return self._es
 
     @property

--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -192,6 +192,14 @@ class Indexer:
         short_key = morphology.short_keys.get(str(passage.text.urn))
         if short_key is None:
             return ""
+
+        token_limit = 50000
+        limit_exceeded = len(tokens) > token_limit
+        if limit_exceeded:
+            print(
+                f"more than {token_limit} tokens detected [urn={passage.urn}] [count={len(tokens)}]"
+            )
+
         thibault = [token["w"] for token in tokens]
         giuseppe = []
         text = morphology.text.get((short_key, str(passage.reference)))
@@ -202,9 +210,13 @@ class Indexer:
             form = morphology.forms[int(form_key) - 1]
             giuseppe.append((form.form, form.lemma))
         missing = chr(0xFFFD)
-        return " ".join(
+        content = " ".join(
             [{None: missing}.get(w, w) for w in align_text(thibault, giuseppe)]
         )
+        if limit_exceeded:
+            print(f"lemma content generated [urn={passage.urn}]")
+
+        return content
 
     def passage_to_doc(self, passage, sort_idx, tokens, word_stats, lemma_content):
         urn = str(passage.urn)

--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -123,6 +123,7 @@ class Indexer:
                         "urn:cts:greekLit:tlg4015.tlg007.opp-grc1",
                         "urn:cts:greekLit:tlg4015.tlg008.opp-grc1",
                         "urn:cts:greekLit:tlg4015.tlg009.opp-grc1",
+                        "urn:cts:greekLit:tlg4016.tlg003.opp-grc2",
                     }
                     if str(text.urn) in exclude:
                         continue

--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -258,6 +258,7 @@ class Indexer:
                 "reference": str(passage.reference),
                 "sort_idx": sort_idx,
                 "content": " ".join([token["w"] for token in tokens]),
+                "raw_content": passage.content,
                 "language": language,
                 "word_count": word_count,
             }

--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -60,26 +60,46 @@ class Indexer:
             morphology = Morphology.load(path)
             print("Morphology loaded")
 
+    def get_urn_obj(self):
+        if not self.urn_prefix:
+            return None
+        return cts.URN(self.urn_prefix)
+
+    def get_urn_prefix_filter(self, urn_obj):
+        if not urn_obj:
+            return None
+        if urn_obj.reference:
+            up_to = cts.URN.NO_PASSAGE
+        elif urn_obj.version:
+            up_to = cts.URN.VERSION
+        elif urn_obj.work:
+            up_to = cts.URN.WORK
+        elif urn_obj.textgroup:
+            up_to = cts.URN.TEXTGROUP
+        elif urn_obj.namespace:
+            up_to = cts.URN.NAMESPACE
+        else:
+            raise ValueError(f'Could not derive prefix filter from "{urn_obj}"')
+
+        value = urn_obj.upTo(up_to)
+        print(f"Applying URN prefix filter: {value}")
+        return value
+
     def index(self):
         cts.TextInventory.load()
         print("Text inventory loaded")
-        if self.urn_prefix:
-            urn_prefix = cts.URN(self.urn_prefix)
-            print(f"Applying URN prefix filter: {urn_prefix.upTo(cts.URN.NO_PASSAGE)}")
-        else:
-            urn_prefix = None
-        texts = dask.bag.from_sequence(
-            self.texts(urn_prefix.upTo(cts.URN.NO_PASSAGE) if urn_prefix else None)
-        )
+        urn_obj = self.get_urn_obj()
+        prefix_filter = self.get_urn_prefix_filter(urn_obj)
+        texts = dask.bag.from_sequence(self.texts(prefix_filter))
 
         if LEMMA_CONTENT:
             # only retrieve greek texts
             texts = texts.filter(lambda t: t.lang == "grc")
 
         passages = texts.map(self.passages_from_text).flatten()
-        if urn_prefix and urn_prefix.reference:
-            print(f"Applying URN reference filter: {urn_prefix.reference}")
-            passages = passages.filter(lambda p: p["urn"] == str(urn_prefix))
+        if urn_obj and urn_obj.reference:
+            print(f"Applying URN reference filter: {urn_obj.reference}")
+            passages = passages.filter(lambda p: p.urn == str(urn_obj))
         if self.limit is not None:
             passages = passages.take(self.limit, npartitions=-1)
         else:

--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -153,8 +153,11 @@ class Indexer:
             try:
                 # tokenized once and passed around as an optimization
                 tokens = passage.tokenize(whitespace=False)
-                words.append((str(passage.text.lang), self.count_words(tokens)))
-                doc = self.passage_to_doc(passage, p.sort_idx, tokens)
+                stats = (str(passage.text.lang), self.count_words(tokens))
+                words.append(stats)
+                doc = self.passage_to_doc(
+                    passage, p.sort_idx, tokens, stats
+                )
             except MemoryError:
                 return words
             except Exception:
@@ -194,7 +197,8 @@ class Indexer:
             [{None: missing}.get(w, w) for w in align_text(thibault, giuseppe)]
         )
 
-    def passage_to_doc(self, passage, sort_idx, tokens):
+    def passage_to_doc(self, passage, sort_idx, tokens, word_stats):
+        language, word_count = word_stats
         return {
             "urn": str(passage.urn),
             "text_group": str(passage.text.urn.upTo(cts.URN.TEXTGROUP)),
@@ -208,6 +212,8 @@ class Indexer:
             "sort_idx": sort_idx,
             "lemma_content": self.lemma_content(passage, tokens),
             "content": " ".join([token["w"] for token in tokens]),
+            "language": language,
+            "word_count": word_count,
         }
 
 

--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -136,7 +136,7 @@ class Indexer:
         try:
             toc = text.toc()
         except Exception as e:
-            print(f"{text.urn} toc error: {e}")
+            print(f"toc error: {e} [urn={text.urn}]")
         else:
             leaves = PreOrderIter(toc.root, filter_=attrgetter("is_leaf"))
             for i, node in enumerate(leaves):
@@ -155,10 +155,10 @@ class Indexer:
             try:
                 passage = cts.passage(urn)
             except cts.PassageDoesNotExist:
-                print(f"Passage {urn} does not exist")
+                print(f"Passage does not exist [urn={urn}]")
                 continue
             except Exception as e:
-                print(f"Error {e}")
+                print(f"Error {e} [urn={urn}]")
                 continue
             try:
                 # tokenized once and passed around as an optimization

--- a/core/scaife_viewer/core/management/commands/indexer.py
+++ b/core/scaife_viewer/core/management/commands/indexer.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from django.core.management.base import BaseCommand
 
 from ...cloud import CloudJob
+from ...conf import settings
 from ...indexer import DirectPusher, Indexer, PubSubPusher
 
 
@@ -43,8 +44,17 @@ class IndexerCommand(BaseCommand):
         print(f"Finished in {elapsed}s")
 
 
-class Command(CloudJob, IndexerCommand):
-    pass
+if settings.SCAIFE_VIEWER_CORE_USE_CLOUD_INDEXER:
+    # NOTE: Adds additional GCE metadata hooks
+    # onto the indexing command
+    class Command(CloudJob, IndexerCommand):
+        pass
+
+
+else:
+
+    class Command(IndexerCommand):
+        pass
 
 
 class Timer:


### PR DESCRIPTION
## Features

- Add `USE_CLOUD_INDEXER` appconf setting (so GCE is not required to run the indexer)
- Add `LEMMA_CONTENT` configuration constant to support a "two-phase" indexing run:
  - Go wide (96 cores) to ingest the corpa in parallel
  - Go deep (961 GB of RAM) to map content to lemmas
- Expand URN prefix support (text group / work / version in addition to passages)
- Index language and word counts at the passage level (refs scaife-viewer/scaife-viewer#421)
- Index raw content (refs scaife-viewer/scaife-viewer#342)



## Fixes

- Add `finalize` methods to direct and pub sub pushers to ensure the push queue is fully emptied

  

## Other improvements

- Update URN exclusion list (for URNs that cannot be lemmatized successfully)
- Add additional debug logging (to help populate possible URNs for the exclusion list)
- Simplify ElasticSearch client instantiation