### PR TITLE
[atlas] Fix to prevent version metadata from clobbering resolver

### DIFF
--- a/atlas/scaife_viewer/atlas/resolvers/default.py
+++ b/atlas/scaife_viewer/atlas/resolvers/default.py
@@ -30,9 +30,9 @@ class LibraryDataResolver:
                 raise FileNotFoundError(version_path)
 
             self.versions[version["urn"]] = {
+                **version,
                 "format": extension,
                 "path": version_path,
-                **version,
             }
 
     def resolve_data_dir_path(self, data_dir_path):


### PR DESCRIPTION
If a version has format or path keys, we should overwrite them.