### PR TITLE
Add setting to redirect from version toc page to reader

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -12,6 +12,12 @@ Default: `False`
 When `False`, to maintain compatability with the MyCapitain resolver,
 the trailing colon will be stripped from URNs.
 
+### REDIRECT_VERSION_LIBRARY_COLLECTION_TO_READER
+
+Default: `True`
+
+When `True`, will redirect a version / exemplar `library_collection` URL to the first passage of the version in the reader`
+
 ### HOOKSET
 
 Default: `"scaife_viewer.core.hooks.DefaultHookSet"`

--- a/core/scaife_viewer/core/conf.py
+++ b/core/scaife_viewer/core/conf.py
@@ -26,6 +26,8 @@ class CoreAppConf(AppConf):
     ALLOW_TRAILING_COLON = False
 
     # Other
+    REDIRECT_VERSION_LIBRARY_COLLECTION_TO_READER = True
+
     HOOKSET = "scaife_viewer.core.hooks.DefaultHookSet"
 
     class Meta:


### PR DESCRIPTION
BI: Add `SCAIFE_VIEWER_CORE_REDIRECT_VERSION_LIBRARY_COLLECTION_TO_READER` setting to disable Library TOC on `scaife-viewer-core`