### PR TITLE
Update preferred token annotation format

### DIFF
--- a/atlas/scaife_viewer/atlas/data_model.py
+++ b/atlas/scaife_viewer/atlas/data_model.py
@@ -12,4 +12,4 @@ content should be re-ingested due to BI schema changes, e.g.:
 * Leveraging the `prepare_atlas_db` management command
 * Comparing a site-level setting to the current VERSION constant
 """
-VERSION = base64.b64encode(b"2020-09-08-001\n").decode()
+VERSION = base64.b64encode(b"2021-02-18-001\n").decode()


### PR DESCRIPTION
**BI**: Require token standoff annotations to use ve_ref value (e.g. `1.1.t1`, where `t<token-position>` is appended to the text part reference (1.1))