### PR TITLE
Fix bugs in customized local resolver

### DIFF
--- a/core/scaife_viewer/core/cts/resolvers.py
+++ b/core/scaife_viewer/core/cts/resolvers.py
@@ -34,7 +34,7 @@ class LocalResolver(CtsCapitainsLocalResolver):
         urn = str(metadata.urn)
         if urn in self.inventory["default"].textgroups:
             try:
-                self.inventory[urn].update(metadata)
+                metadata = self.inventory[urn].update(metadata)
             except UnknownCollection as e:
                 if self.RAISE_ON_UNKNOWN_COLLECTION:
                     raise e
@@ -54,7 +54,7 @@ class LocalResolver(CtsCapitainsLocalResolver):
         work_urn = str(metadata.urn)
         if work_urn in text_group_metadata.works:
             try:
-                self.inventory[work_urn].update(metadata)
+                metadata = self.inventory[work_urn].update(metadata)
             except UnknownCollection as e:
                 if self.RAISE_ON_UNKNOWN_COLLECTION:
                     raise e

--- a/core/scaife_viewer/core/cts/resolvers.py
+++ b/core/scaife_viewer/core/cts/resolvers.py
@@ -48,7 +48,6 @@ class LocalResolver(CtsCapitainsLocalResolver):
         return metadata
 
     def process_work(self, text_group_metadata, path):
-        text_group_urn = str(text_group_metadata.urn)
         with open(path) as f:
             metadata = XmlCtsWorkMetadata.parse(resource=f, parent=text_group_metadata,)
         work_urn = str(metadata.urn)

--- a/core/scaife_viewer/core/cts/resolvers.py
+++ b/core/scaife_viewer/core/cts/resolvers.py
@@ -79,6 +79,13 @@ class LocalResolver(CtsCapitainsLocalResolver):
             # NOTE: Don't try and continue processing the text
             return
 
+        if metadata.path:
+            # NOTE: We use metadata.path being populated as a way
+            # to determine if the text has been processed by this function.
+            # This avoids hitting an errant FileNotFoundError if the texts
+            # are stored across multiple data directories (corpora).
+            return
+
         metadata.path = os.path.join(
             base_path,
             "{text_group}.{work}.{version}.xml".format(
@@ -144,10 +151,11 @@ class LocalResolver(CtsCapitainsLocalResolver):
                             text_group_metadata, work_path
                         )
                         for text_urn in work_metadata.texts:
-                            self.process_text(
+                            processed = self.process_text(
                                 text_urn, os.path.dirname(work_path), to_remove
                             )
-                            repo_metadata["texts"].append(text_urn)
+                            if processed:
+                                repo_metadata["texts"].append(text_urn)
                 except UndispatchedTextError as e:
                     self.logger.warning(f"Error dispatching {text_group_path}: {e}")
                     if self.RAISE_ON_UNDISPATCHED:

--- a/core/scaife_viewer/core/cts/resolvers.py
+++ b/core/scaife_viewer/core/cts/resolvers.py
@@ -100,7 +100,7 @@ class LocalResolver(CtsCapitainsLocalResolver):
                     ckwargs["child"] = cites[-1]
                 cites.append(XmlCtsCitation(**ckwargs))
             metadata.citation = cites[-1]
-            self.logger.info(f"{metadata.path} has been parsed")
+            self.logger.debug(f"{metadata.path} has been parsed")
             if not metadata.citation.is_set():
                 to_remove.append(urn)
                 self.logger.warning(f"{metadata.path} has no passages")

--- a/core/scaife_viewer/core/cts/toc.py
+++ b/core/scaife_viewer/core/cts/toc.py
@@ -133,7 +133,7 @@ class RefNode(anytree.NodeMixin):
 
     def __repr__(self):
         if self.is_root:
-            return f"<RefRootNode>"
+            return "<RefRootNode>"
         else:
             return f"<RefNode {self.reference}>"
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email="jtauber+scaife@jtauber.com",
     description="Scaife Viewer Backend :: Core Functionality",
     name="scaife-viewer-core",
-    version="0.1a7",
+    version="0.1a8",
     url="https://github.com/scaife-viewer/backend/",
     license="MIT",
     packages=find_packages(),


### PR DESCRIPTION
Fixes an issue introduced in [scaife-viewer-core@0.1-a5](https://github.com/scaife-viewer/backend/releases/tag/scaife-viewer-core%400.1-a5)

- Ensure that `XML<*>Metadata` objects are _updated_, rather than replaced when traversing data directories.  This supports, for example, multiple corpora contributing to a text group or work
- Ensure that a version text is only processed by the resolver once.  Otherwise, a resolver may try and process the text using the wrong data directory and not be able to locate the TEI-XML file.  This would cause the version text to be removed from the resolver.