### PR TITLE
Expose ImageROI fields via GraphQL

### DIFF
--- a/atlas/scaife_viewer/atlas/schema.py
+++ b/atlas/scaife_viewer/atlas/schema.py
@@ -31,6 +31,7 @@ from .models import (
     GrammaticalEntry,
     GrammaticalEntryCollection,
     ImageAnnotation,
+    ImageROI,
     MetricalAnnotation,
     NamedEntity,
     NamedEntityCollection,
@@ -865,6 +866,19 @@ class ImageAnnotationNode(DjangoObjectType):
         model = ImageAnnotation
         interfaces = (relay.Node,)
         filterset_class = ImageAnnotationFilterSet
+
+
+class ImageROINode(DjangoObjectType):
+    data = generic.GenericScalar()
+
+    class Meta:
+        model = ImageROI
+        fields = [
+            "coordinates_value",
+            "image_identifier",
+            "text_parts",
+            "text_annotations",
+        ]
 
 
 class AudioAnnotationNode(DjangoObjectType):


### PR DESCRIPTION
This change uses the pre-existing ImageROI model and makes it queryable over the GraphQL API. We need these data to be able to map regions of interest between text_parts and manuscript images.

@jacobwegner -- I think it's ready for review. The changes were pretty straightforward once I got the database set up. Thank you for your help with onboarding!