### PR TITLE
[atlas] Support for TEI fallback mode

### DIFF
--- a/atlas/scaife_viewer/atlas/schema.py
+++ b/atlas/scaife_viewer/atlas/schema.py
@@ -426,8 +426,11 @@ class VersionNode(AbstractTextPartNode):
         has_token_annotations = TokenAnnotation.objects.filter(
             token__text_part__urn__startswith=obj.urn
         ).exists()
+        fallback_mode = obj.metadata.get("fallback_display_mode", False)
+        default_mode = not fallback_mode
         data = {
-            "default": True,
+            "default": default_mode,
+            "fallback": fallback_mode,
             "grammatical-entries": GrammaticalEntry.objects.filter(
                 tokens__text_part__urn__startswith=obj.urn
             ).exists(),

--- a/atlas/scaife_viewer/atlas/schema.py
+++ b/atlas/scaife_viewer/atlas/schema.py
@@ -517,6 +517,10 @@ class TextPartByLemmaNode(DjangoObjectType):
 
 class PassageTextPartNode(DjangoObjectType):
     label = String()
+    metadata = generic.GenericScalar()
+
+    def resolve_metadata(obj, *args, **kwargs):
+        return camelize(obj.metadata)
 
     class Meta:
         model = TextPart


### PR DESCRIPTION
See https://github.com/scaife-viewer/beyond-translation-site/pull/101.