### PR TITLE
Add ang code mapping

### DIFF
--- a/atlas/scaife_viewer/atlas/constants.py
+++ b/atlas/scaife_viewer/atlas/constants.py
@@ -84,6 +84,7 @@ NAMED_ENTITY_KINDS = [
 
 HUMAN_FRIENDLY_LANGUAGE_MAP = {
     "eng": "English",
+    "ang": "English, Old (ca.450-1100)",
     "fa": "Farsi",
     "far": "Farsi",
     "fre": "French",


### PR DESCRIPTION
Supports https://github.com/scaife-viewer/beyond-translation-site/pull/126

We might consider:

https://github.com/jacksonllee/iso639

Marlowe might be updated for "enm" at some point too: https://en.wikipedia.org/wiki/Christopher_Marlowe

enm
English, Middle (1100-1500)