### PR TITLE
[atlas] Add support for ingesting text annotations in JSON Lines format

### DIFF
--- a/atlas/scaife_viewer/atlas/importers/text_annotations.py
+++ b/atlas/scaife_viewer/atlas/importers/text_annotations.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 
 import jsonlines
@@ -8,9 +9,15 @@ from scaife_viewer.atlas.conf import settings
 from ..models import (
     TEXT_ANNOTATION_KIND_SCHOLIA,
     TEXT_ANNOTATION_KIND_SYNTAX_TREE,
+    Node,
     TextAnnotation,
 )
+from ..utils import chunked_bulk_create
 
+
+logger = logging.getLogger(__name__)
+
+TextAnnotationThroughModel = TextAnnotation.text_parts.through
 
 ANNOTATIONS_DATA_PATH = Path(
     settings.SV_ATLAS_DATA_DIR, "annotations", "text-annotations"
@@ -52,6 +59,50 @@ def _prepare_text_annotations(path, counters, kind):
     return to_create
 
 
+# TODO: Determine if we want some of these bulk methods to move to a classmethod
+def _bulk_prepare_text_annotation_through_objects(qs):
+    logger.info("Extracting URNs from text annotation references")
+    qs_with_references = qs.exclude(data__references=None)
+    through_lookup = {}
+    through_values = qs_with_references.values("id", "data__references")
+    urns = set()
+    for row in through_values:
+        through_lookup[row["id"]] = row["data__references"]
+        urns.update(row["data__references"])
+    msg = f"URNs extracted: {len(urns)}"
+    logger.info(msg)
+
+    logger.info("Building URN to Node pk lookup")
+    node_urn_pk_values = Node.objects.filter(urn__in=urns).values_list("urn", "pk")
+    node_lookup = {}
+    for urn, pk in node_urn_pk_values:
+        node_lookup[urn] = pk
+
+    logger.info("Preparing through objects for insert")
+    to_create = []
+    for textannotation_id, urns in through_lookup.items():
+        for urn in urns:
+            # TODO: Remove this lookup fallback
+            node_id = node_lookup.get(urn, None)
+            if node_id:
+                to_create.append(
+                    TextAnnotationThroughModel(
+                        node_id=node_id, textannotation_id=textannotation_id
+                    )
+                )
+    return to_create
+
+
+def _resolve_text_annotation_text_parts(qs):
+    prepared_objs = _bulk_prepare_text_annotation_through_objects(qs)
+
+    relation_label = TextAnnotationThroughModel._meta.verbose_name_plural
+    msg = f"Bulk creating {relation_label}"
+    logger.info(msg)
+
+    chunked_bulk_create(TextAnnotationThroughModel, prepared_objs)
+
+
 def import_text_annotations(reset=False):
     if reset:
         TextAnnotation.objects.all().delete()
@@ -73,8 +124,8 @@ def import_text_annotations(reset=False):
             )
         )
 
-    created = len(TextAnnotation.objects.bulk_create(to_create, batch_size=500))
-    print(f"Created text annotations [count={created}]")
+    logger.info("Inserting TextAnnotation objects")
+    chunked_bulk_create(TextAnnotation, to_create)
 
-    for text_annotation in TextAnnotation.objects.all():
-        text_annotation.resolve_references()
+    logger.info("Generating TextAnnotation through models...")
+    _resolve_text_annotation_text_parts(TextAnnotation.objects.all())


### PR DESCRIPTION
Using [JSON Lines](https://jsonlines.org/) makes it a bit easier to diff the backing data files, and it is also likely more performant.