### PR TITLE
Add support for indexing of normalized keywords for metadata collections

### DIFF
--- a/atlas/scaife_viewer/atlas/backports/scaife_viewer/search/fixtures/base_template.json
+++ b/atlas/scaife_viewer/atlas/backports/scaife_viewer/search/fixtures/base_template.json
@@ -75,6 +75,14 @@
             "icu_folding"
           ]
         }
+      },
+       "normalizer": {
+        "fulltext_normalizer": {
+          "type": "custom",
+          "filter": [
+            "icu_folding"
+          ]
+        }
       }
     }
   }

--- a/atlas/scaife_viewer/atlas/backports/scaife_viewer/search/templates.py
+++ b/atlas/scaife_viewer/atlas/backports/scaife_viewer/search/templates.py
@@ -6,7 +6,10 @@ from scaife_viewer.atlas.conf import settings
 def text_field_template():
     return {
         "type": "text",
-        "fields": {"keyword": {"ignore_above": 256, "type": "keyword"}},
+        "fields": {
+            "keyword": {"ignore_above": 256, "type": "keyword",},
+            "analyzer": "fulltext_analyzer",
+        },
     }
 
 

--- a/atlas/scaife_viewer/atlas/backports/scaife_viewer/search/templates.py
+++ b/atlas/scaife_viewer/atlas/backports/scaife_viewer/search/templates.py
@@ -4,12 +4,17 @@ from scaife_viewer.atlas.conf import settings
 
 
 def text_field_template():
+    # TODO: make this opt in
     return {
         "type": "text",
         "fields": {
-            "keyword": {"ignore_above": 256, "type": "keyword",},
-            "analyzer": "fulltext_analyzer",
+            "keyword": {
+                "ignore_above": 256,
+                "type": "keyword",
+                "normalizer": "fulltext_normalizer",
+            },
         },
+        "analyzer": "fulltext_analyzer",
     }
 
 

--- a/atlas/scaife_viewer/atlas/backports/scaife_viewer/search/templates.py
+++ b/atlas/scaife_viewer/atlas/backports/scaife_viewer/search/templates.py
@@ -11,6 +11,10 @@ def text_field_template():
             "keyword": {
                 "ignore_above": 256,
                 "type": "keyword",
+            },
+            "normalizedKeyword": {
+                "ignore_above": 256,
+                "type": "keyword",
                 "normalizer": "fulltext_normalizer",
             },
         },

--- a/atlas/scaife_viewer/atlas/importers/text_annotations.py
+++ b/atlas/scaife_viewer/atlas/importers/text_annotations.py
@@ -6,12 +6,12 @@ import jsonlines
 
 from scaife_viewer.atlas.conf import settings
 
-from ..models import (
+# FIXME: Hooksets
+from ..constants import (
     TEXT_ANNOTATION_KIND_SCHOLIA,
     TEXT_ANNOTATION_KIND_SYNTAX_TREE,
-    Node,
-    TextAnnotation,
 )
+from ..models import Node, TextAnnotation
 from ..utils import chunked_bulk_create
 
 
@@ -110,6 +110,7 @@ def import_text_annotations(reset=False):
     to_create = []
     counters = dict(idx=0)
 
+    # FIXME: hooksets
     scholia_annotation_paths = get_paths(ANNOTATIONS_DATA_PATH)
     for path in scholia_annotation_paths:
         to_create.extend(

--- a/atlas/setup.py
+++ b/atlas/setup.py
@@ -35,7 +35,7 @@ setup(
         "django-treebeard>=4.3.0,<5",
         "Django>=2.2.15,<3",
         # @@@ can be dropped in Django 3.1+
-        "django-jsonfield-backport==1.0.0",
+        "django-jsonfield-backport>=1.0.0,<2",
         "graphene-django==2.6.0",
         # @@@ can be dropped in Python > 3.8
         "importlib-resources>=5.1.2,<6",


### PR DESCRIPTION
## Features
- Adds `normalizedKeyword` to improve search experience in metadata collections (currently only implemented in Scholarly Editions)

## Fixes
- Fix a circular import error

## Other improvements
- Updates pinning for django-jsonfield-backport