### PR TITLE
Update search and indexer for ES 7

### DIFF
--- a/core/scaife_viewer/core/indexer.py
+++ b/core/scaife_viewer/core/indexer.py
@@ -380,7 +380,7 @@ class DirectPusher:
         print(msg)
         # logger.info(msg)
 
-        metadata = {"_op_type": "index", "_index": self.index_name, "_type": "text"}
+        metadata = {"_op_type": "index", "_index": self.index_name}
         docs = ({"_id": doc["urn"], **metadata, **doc} for doc in self.docs)
         elasticsearch.helpers.bulk(self.es, docs)
         self.docs.clear()

--- a/core/scaife_viewer/core/search.py
+++ b/core/scaife_viewer/core/search.py
@@ -73,7 +73,7 @@ class SearchQuery:
         self.total_count = None
 
     def query_index(self):
-        return {"index": settings.ELASTICSEARCH_INDEX_NAME, "doc_type": "text"}
+        return {"index": settings.ELASTICSEARCH_INDEX_NAME}
 
     def query_sort(self):
         if not self.sort_by:

--- a/core/setup.py
+++ b/core/setup.py
@@ -36,7 +36,7 @@ setup(
         "dask[bag]==1.1.0",
         "django_appconf>=1.0.4",
         "Django>=2.2,<3.0",
-        "elasticsearch==6.3.1",
+        "elasticsearch==7.17.7",
         "google-auth==1.6.2",
         "google-cloud-pubsub==0.39.1",
         "lxml>=4.3.5",

--- a/core/setup.py
+++ b/core/setup.py
@@ -33,7 +33,7 @@ setup(
         "anytree==2.4.3",
         "certifi==2018.11.29",
         "click>=8.0.0",
-        "dask[bag]==1.1.0",
+        "dask[bag]==2022.1.0",
         "django_appconf>=1.0.4",
         "Django>=2.2,<3.0",
         "elasticsearch==7.17.7",


### PR DESCRIPTION
- Updates Dask and ElasticSearch packages
- Remove `_type` from index mapping and `doc_type` from search query requests (refs https://bonsai.io/docs/upgrading-to-es-7)