### PR TITLE
Fix: Ensure that Pandas does not treat "None" as NaN

### DIFF
--- a/atlas/scaife_viewer/atlas/parallel_tokenizers.py
+++ b/atlas/scaife_viewer/atlas/parallel_tokenizers.py
@@ -79,7 +79,9 @@ def insert_from_csv(path):
         django.conf.settings.SV_ATLAS_DB_LABEL
     ]["NAME"]
     conn = sqlite3.connect(sv_atlas_db_name)
-    pandas.read_csv(path).to_sql(table_name, conn, if_exists="append", index=False)
+    pandas.read_csv(path, keep_default_na=False).to_sql(
+        table_name, conn, if_exists="append", index=False
+    )
     end = time.time()
     logger.info(f"Inserted tokens [elapsed={end-start}]", file=sys.stderr)
 


### PR DESCRIPTION
Refs https://github.com/scaife-viewer/beyond-translation-site/commit/d4efc2aae249edd8f56f222b0ff694104cf209e8.

The issue was that some English texts had the word `None`, which Pandas 2 casts to its `NaN` value.  Then, when we generate SQL statements from Pandas, Pandas tries to insert null values.

Read https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html and found `keep_default_na`; seemed to work, so if we test that, we can use Pandas 2 instead of 1.